### PR TITLE
Fix timestamp data type

### DIFF
--- a/tap_decentraland_api/snapshot_dao_streams.py
+++ b/tap_decentraland_api/snapshot_dao_streams.py
@@ -247,6 +247,7 @@ class SnapshotVotesStream(SnapshotDaoChildStream):
     def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
         """Generate row id"""
         row['rowId'] = "|".join([row['proposal_id'],row['voter']])
+        row['timestamp'] = datetime.datetime.fromtimestamp(row['timestamp'])
 
         return row
     
@@ -256,5 +257,5 @@ class SnapshotVotesStream(SnapshotDaoChildStream):
         Property("voter", StringType, required=True),
         Property("choice", IntegerType),
         Property("voting_power", IntegerType),
-        Property("timestamp", IntegerType),
+        Property("timestamp", DateTimeType),
     ).to_dict()


### PR DESCRIPTION
The timestamp for votes was stored as an integer, switching to timestamp