### PR TITLE
Fix scenes loader

### DIFF
--- a/tap_decentraland_api/scenes_streams.py
+++ b/tap_decentraland_api/scenes_streams.py
@@ -245,7 +245,7 @@ class SceneStream(DecentralandStreamAPIStream):
                     row['metadata']['scene']['parcels'] = json.dumps(metadata['scene']['parcels'])
                 if 'base' in metadata['scene']:
                     row['metadata']['scene']['base'] = json.dumps(metadata['scene']['base'])
-            if 'policy' in metadata:
+            if 'policy' in metadata and metadata['policy'] is not None:
                 if 'blacklist' in metadata['policy']:
                     row['metadata']['policy']['blacklist'] = json.dumps(metadata['policy']['blacklist'])
             if 'requiredPermissions' in metadata:


### PR DESCRIPTION
The metadata['policy'] field can come with empty value:
File "/project/.meltano/extractors/tap-decentraland-api/venv/lib/python3.8/site-packages/tap_decentraland_api/scenes_streams.py", line 249, in post_process
[2022-01-28 13:36:25,478] {ecs.py:324} INFO - [2022-01-28T13:35:48.248000] tap-decentraland-api |     if 'blacklist' in metadata['policy']:
[2022-01-28 13:36:25,478] {ecs.py:324} INFO - [2022-01-28T13:35:48.248000] tap-decentraland-api | TypeError: argument of type 'NoneType' is not iterable